### PR TITLE
added playerPrefID to the default frontend script

### DIFF
--- a/inc/Block.php
+++ b/inc/Block.php
@@ -152,11 +152,14 @@ class Block
       self::$script_localized = true;
     endif;
 
+    $playerPrefId = !empty( $attributes['invintus_player_pref_id'] ) ? $attributes['invintus_player_pref_id'] : $settings->get_option( 'invintus_player_preference_default' );
+
     return sprintf(
-      '<div %s><div class="invintus-player" data-eventid="%s" data-simple="%s"></div></div>',
+      '<div %s><div class="invintus-player" data-eventid="%s" data-simple="%s" data-playerid="%s"></div></div>',
       get_block_wrapper_attributes( apply_filters( 'invintus/block/attributes', [] ) ),
       esc_attr( $attributes['invintus_event_id'] ?? '' ),
-      esc_attr( $attributes['invintus_event_is_simple'] ?? false )
+      esc_attr( $attributes['invintus_event_is_simple'] ?? false ),
+      esc_attr( $playerPrefId )
     );
   }
 }

--- a/inc/Block.php
+++ b/inc/Block.php
@@ -3,6 +3,7 @@
 namespace Taproot\Invintus;
 
 use WP_Block_Type_Registry;
+use Taproot\Invintus\Settings;
 
 class Block
 {
@@ -138,11 +139,14 @@ class Block
    */
   private function render_block_html( $attributes )
   {
+    $settings = new Settings();
+
     if ( !self::$script_localized ):
       wp_enqueue_script( 'invintus-player-script', $this->invintus()->get_invintus_script_url(), [], null, true );
 
       wp_localize_script( 'invintus-player-script', 'invintusConfig', [
-        'clientId' => $this->client_id,
+        'clientId'     => $this->client_id,
+        'playerPrefID' => $settings->get_option( 'invintus_player_preference_default' ) ?? '',
       ] );
 
       self::$script_localized = true;

--- a/inc/Settings.php
+++ b/inc/Settings.php
@@ -113,6 +113,7 @@ class Settings
       'nonce'                => wp_create_nonce( 'wp_rest' ),
       'clientId'             => $this->get_client_id(),
       'defaultPlayerId'      => $this->get_option( 'invintus_player_preference_default' ),
+      'playerPreferences'    => $this->get_invintus_player_preferences(),
       'siteUrl'              => get_site_url(),
       'playerUrl'            => sprintf( '%s/%s', get_site_url(), $this->invintus()->get_preview_url() ),
       'defaultWatchUrl'      => get_home_url( null, $this->invintus()->get_default_watch_endpoint() ),

--- a/src/block.json
+++ b/src/block.json
@@ -18,6 +18,10 @@
     "invintus_event_is_simple": {
       "type": "boolean",
       "default": false
+    },
+    "invintus_player_pref_id": {
+      "type": "string",
+      "default": ""
     }
   },
   "textdomain": "invintus",

--- a/src/render.php
+++ b/src/render.php
@@ -4,6 +4,7 @@
  */
 ?>
 <div <?php echo get_block_wrapper_attributes(); ?>>
-  <div class="invintus-player" data-eventid="<?php esc_attr_e( $attributes['invintus_event_id'] ); ?>"
-    data-simple="<?php esc_attr_e( $attributes['invintus_event_is_simple'] ); ?>"></div>
+  <div class="invintus-player" data-eventid="<?php echo esc_attr( $attributes['invintus_event_id'] ); ?>"
+    data-simple="<?php echo esc_attr( $attributes['invintus_event_is_simple'] ); ?>"
+    data-playerid="<?php echo esc_attr( $attributes['invintus_player_pref_id'] ); ?>"></div>
 </div>

--- a/src/view.js
+++ b/src/view.js
@@ -33,15 +33,12 @@ const invintusWP = ( () => {
 
           const config = {
             clientID: invintusConfig.clientId,
-            playerPrefID: invintusConfig.playerPrefID,
+            playerPrefID: $player.dataset.playerid,
             eventID: $player.dataset.eventid,
             simple: $player.dataset.simple,
           }
 
-          console.log( config );
-
           Invintus.launch( config )
-
         } )
       }
     },

--- a/src/view.js
+++ b/src/view.js
@@ -33,10 +33,12 @@ const invintusWP = ( () => {
 
           const config = {
             clientID: invintusConfig.clientId,
-            playerPrefID: invintusConfig.defaultPlayerId,
+            playerPrefID: invintusConfig.playerPrefID,
             eventID: $player.dataset.eventid,
             simple: $player.dataset.simple,
           }
+
+          console.log( config );
 
           Invintus.launch( config )
 


### PR DESCRIPTION
This update should fix the issue with the player preferences not properly being applied to the player on the front-end. 

I also added a new option to the actual player block itself that will allow you to override the player preference per block.

<img width="280" alt="image" src="https://github.com/user-attachments/assets/47ca82a5-69be-4ff0-868b-f76cad1891f5" />

I also cleaned up some code to fall more inline with WP standards.