### PR TITLE
Default player preference patch

### DIFF
--- a/src/edit.js
+++ b/src/edit.js
@@ -158,11 +158,11 @@ export default function Edit( { attributes, setAttributes, isSelected } ) {
                 label={ __( 'Player Preference', 'invintus' ) }
                 value={ playerPrefId }
                 options={ [
-                  { value: '', label: __( 'Default', 'invintus' ) },
+                  { value: '', label: __( 'Global Player Preference', 'invintus' ) },
                   ...playerPreferences
                 ] }
                 onChange={ onChangePlayerPref }
-                help={ __( 'Select a player preference or leave as default to use the global setting.', 'invintus' ) }
+                help={ __( 'Select a player preference or leave as default to use the global player preference.', 'invintus' ) }
               />
               <ToggleControl label="Use Simple Player" checked={isSimpleEvent} onChange={onChangeIsSimple} />
             </PanelBody>

--- a/src/render.php
+++ b/src/render.php
@@ -2,9 +2,13 @@
 /**
  * @see https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-metadata.md#render
  */
+
+// Get the default player preference ID from settings if none is set in block
+$settings       = get_option( 'invintus_video_settings', [] );
+$player_pref_id = !empty( $attributes['invintus_player_pref_id'] ) ? $attributes['invintus_player_pref_id'] : ( $settings['invintus_player_preference_default'] ?? '' );
 ?>
 <div <?php echo get_block_wrapper_attributes(); ?>>
   <div class="invintus-player" data-eventid="<?php echo esc_attr( $attributes['invintus_event_id'] ); ?>"
     data-simple="<?php echo esc_attr( $attributes['invintus_event_is_simple'] ); ?>"
-    data-playerid="<?php echo esc_attr( $attributes['invintus_player_pref_id'] ); ?>"></div>
+    data-playerid="<?php echo esc_attr( $player_pref_id ); ?>"></div>
 </div>


### PR DESCRIPTION
This should fix the issue where the default player preference wasn't being pulled if one wasn't selected by the block (which is the default).

I also updated the block's preference dropdown to help clarify the first option.