### PR TITLE
Add event description meta and update existing filter to allow for more flexible meta creation

### DIFF
--- a/inc/API.php
+++ b/inc/API.php
@@ -806,7 +806,7 @@ class API extends WP_REST_Controller
   {
     $event = $this->maybe_get( $data, 'event' );
 
-    if ( !$event ) return apply_filters( 'invintus/data/prepare', [] );
+    if ( !$event ) return apply_filters( 'invintus/data/prepare', [], [] );
 
     $post_date  = esc_attr( $this->maybe_get( $event, 'startDateTime', '' ) );
     $is_private = (bool) $this->maybe_get( $event, 'private', '' );
@@ -848,7 +848,7 @@ class API extends WP_REST_Controller
     // Override status if it's a private event
     if ( $is_private ) $data['post_status'] = 'private';
 
-    return apply_filters( 'invintus/data/prepare', $data );
+    return apply_filters( 'invintus/data/prepare', $data, $event );
   }
 
   /**

--- a/inc/API.php
+++ b/inc/API.php
@@ -680,7 +680,7 @@ class API extends WP_REST_Controller
    */
   private function get_post_meta_keys()
   {
-    return ['event_id', 'custom_id', 'caption', 'thumbnail', 'audio', 'location', 'total_runtime'];
+    return ['event_id', 'custom_id', 'event_description', 'caption', 'thumbnail', 'audio', 'location', 'total_runtime'];
   }
 
   /**
@@ -820,21 +820,22 @@ class API extends WP_REST_Controller
     $event_id = end( $_event_id );
 
     $data = [
-      'edit_date'     => true,
-      'post_title'    => $this->prepare_title( $this->maybe_get( $event, 'title', '' ) ),
-      'post_name'     => sanitize_title_with_dashes( $this->prepare_title( $this->maybe_get( $event, 'title', '' ) ) ) . '-' . $event_id,
-      'post_date'     => $post_date,
-      'post_status'   => $this->map_statuses( $this->maybe_get( $event, 'eventStatus', '' ) ),
-      'post_content'  => $this->prepare_content( $event_id, $this->maybe_get( $event, 'description', '' ) ),
-      'post_type'     => $this->invintus()->get_cpt_slug(),
-      'event_id'      => esc_attr( $event_id ),
-      'custom_id'     => esc_attr( $this->maybe_get( $event, 'customID', '' ) ),
-      'caption'       => esc_url( $this->maybe_get( $event, 'captionPath', '' ) ),
-      'thumbnail'     => esc_url( $this->maybe_get( $event, 'videoThumbnail', '' ) ),
-      'audio'         => esc_url( $this->maybe_get( $event, 'publishedAudio', '' ) ),
-      'location'      => esc_url( $this->maybe_get( $event, 'locationName', '' ) ),
-      'total_runtime' => esc_attr( $this->maybe_get( $event, 'totalRunTime', '' ) ),
-      'taxonomies'    => [
+      'edit_date'         => true,
+      'post_title'        => $this->prepare_title( $this->maybe_get( $event, 'title', '' ) ),
+      'post_name'         => sanitize_title_with_dashes( $this->prepare_title( $this->maybe_get( $event, 'title', '' ) ) ) . '-' . $event_id,
+      'post_date'         => $post_date,
+      'post_status'       => $this->map_statuses( $this->maybe_get( $event, 'eventStatus', '' ) ),
+      'post_content'      => $this->prepare_content( $event_id, $this->maybe_get( $event, 'description', '' ) ),
+      'post_type'         => $this->invintus()->get_cpt_slug(),
+      'event_id'          => esc_attr( $event_id ),
+      'custom_id'         => esc_attr( $this->maybe_get( $event, 'customID', '' ) ),
+      'event_description' => esc_attr( $this->maybe_get( $event, 'description', '' ) ),
+      'caption'           => esc_url( $this->maybe_get( $event, 'captionPath', '' ) ),
+      'thumbnail'         => esc_url( $this->maybe_get( $event, 'videoThumbnail', '' ) ),
+      'audio'             => esc_url( $this->maybe_get( $event, 'publishedAudio', '' ) ),
+      'location'          => esc_url( $this->maybe_get( $event, 'locationName', '' ) ),
+      'total_runtime'     => esc_attr( $this->maybe_get( $event, 'totalRunTime', '' ) ),
+      'taxonomies'        => [
         'invintus_tag' => $this->maybe_get( $event, 'keywords', [] ),
         // 'invintus_category' => isset( $event['categories'] ) ? $event['categories'] : []
       ],

--- a/inc/Metadata.php
+++ b/inc/Metadata.php
@@ -63,6 +63,7 @@ class Metadata
     $meta_fields = [
       'invintus_event_id',
       'invintus_custom_id',
+      'invintus_event_description',
       'invintus_caption',
       'invintus_audio',
       'invintus_location',


### PR DESCRIPTION
This PR makes two small updates:

1. It adds an `invintus_event_description` meta key to the default list of meta created for Invintus events imported via webhooks.
2. It adds the raw webhook event data array as an additional argument to the existing `invintus/data/prepare` filter

The intention behind the second update is to provide a more flexible method for developers to add additional meta fields derived from Invintus webhook data using [meta_input](https://developer.wordpress.org/reference/functions/wp_insert_post/#comment-1710) argument. A hypothetical example:

```
// This would add my target key from the Invintus event data to the post meta
add_filter( 'invintus/data/prepare', function( $data, $event ){
    if (isset($event['some_invintus_key'])) {
        $data['meta_input'] = [
            'some_invintus_key' => $event['some_invintus_key']
        ];

    }
    
    return $data;
} , 10, 2 );
```