### PR TITLE
Add type: wordpress-plugin to composer.json to help with setting up custom installation paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "name": "invintus/invintus-wp-plugin",
+  "type": "wordpress-plugin",
   "autoload": {
     "psr-4": {
       "Taproot\\Invintus\\": "inc/"


### PR DESCRIPTION
Super tiny PR which adds a type of `wordpress-plugin` which is one of the [several supported WordPress types for the Composer installers package](https://github.com/composer/installers#current-supported-package-types). This allows you to set up custom installer paths for WP plugins like this via your project's `composer.json` file:

```
"extra": {
  "installer-paths": {
    "wp/wp-content/plugins/{$name}": [
      "type:wordpress-plugin"
    ],
  },
}
```