### PR TITLE
Release/2.0.12

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -16,5 +16,9 @@
 /create-release.js
 /.DS_Store
 /CLAUDE.md
+/.claude
+/.wp-env.json
+/.wp-env.override.json
+/scripts
 /.dist
 /.dist-push

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,9 @@ jobs:
           npm ci
           composer install --no-dev --optimize-autoloader
 
+      - name: 🔨 Build assets
+        run: npm run build
+
       - name: 📚 Extract Tag Version
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 node_modules
 yarn.lock
 composer.lock
-package-lock.json
 yarn-error.log
 npm-debug.log
 npm-debug.log.*
@@ -15,3 +14,7 @@ build/
 .dist/
 /.dist-push
 CLAUDE.md
+.claude/
+.wp-env.override.json
+.dist-candidate/
+.local-mu-plugins/

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,11 @@
+{
+  "core": "https://wordpress.org/wordpress-6.6.2.zip",
+  "phpVersion": "8.1",
+  "plugins": ["."],
+  "config": {
+    "WP_DEBUG": true,
+    "WP_DEBUG_LOG": true,
+    "WP_DEBUG_DISPLAY": false,
+    "SCRIPT_DEBUG": false
+  }
+}

--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ EOF'
 
 After this the Settings page can save, REST routes resolve, and the block editor works normally. The file persists for the life of the env -- only re-run after a destroy.
 
+To do the whole "wipe everything and start over" cycle in one shot (destroy + rebuild dist + start + bootstrap):
+
+```bash
+npm run env:reset
+```
+
+That runs `scripts/reset-env.sh`. It destroys the wp-env database, rebuilds `build/` and `.dist-candidate/`, brings the env back up, and applies the bootstrap above. Use it to verify the "fresh clone" recipe end-to-end or when env state is the suspected cause of a bug. Does not touch `node_modules` -- delete that manually first if you also want a fresh `npm install`.
+
 ### Traditional setup
 
 Clone into an existing WP install:

--- a/README.md
+++ b/README.md
@@ -195,13 +195,13 @@ Releases are driven by **git tags** on this repo. The CI workflow ([`.github/wor
 3. Commit the version bump on `main`.
 4. Tag and push:
    ```bash
-   git tag v2.0.11
-   git push origin v2.0.11
+   git tag v2.0.12
+   git push origin v2.0.12
    ```
 5. The `Build and Deploy to Dist Repo` workflow fires on the `v*.*.*` tag and:
-   - Runs `npm ci` and `composer install --no-dev --optimize-autoloader`
+   - Runs `npm ci`, `composer install --no-dev --optimize-autoloader`, and `npm run build`
    - Clones the dist repo, wipes it, and copies in `build assets inc vendor templates views invintus.php LICENSE doc.md` plus a stripped `composer.json`
-   - Commits, tags `v2.0.11` on the dist repo, and creates a GitHub Release there with `invintus-wp-plugin.zip` attached
+   - Commits, tags `v2.0.12` on the dist repo, and creates a GitHub Release there with `invintus-wp-plugin.zip` attached
 
 ### Local fallback: `create-release.js`
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Spins up a Dockerized WP at `http://localhost:8888`, mounts this repo as a plugi
 
 ```bash
 npm install
+npm run dist:build
 npm run env:start
 ```
 
@@ -67,7 +68,31 @@ Then create `.wp-env.override.json` (gitignored) at the repo root:
 
 Other env scripts: `env:stop`, `env:destroy`, `env:clean`, `env:logs`, `env:wp` (wp-cli passthrough), `env:composer`, `env:phpcs`.
 
-> Note: wp-env 9.x does not auto-write `.htaccess`, so pretty REST URLs (`/wp-json/...`) return Apache 404s on a fresh install. Either use the query-string form (`/index.php?rest_route=/...`) or write a standard WP `.htaccess` once into the container. Logging into wp-admin and saving the Permalinks page is the simplest fix.
+#### One-time bootstrap after a fresh `env:start`
+
+After every `env:destroy` + `env:start`, WP boots with Plain permalinks and no `.htaccess`. Pretty REST URLs (`/wp-json/...`) return Apache 404s until both are fixed. The "Save Permalinks in wp-admin" trick reports success but doesn't actually write `.htaccess` -- `/var/www/html` is owned by `root` inside the wp-env container so the `www-data` PHP process can't write there. Do it from the host instead:
+
+```sh
+# 1. set a non-plain permalink structure
+npx wp-env run cli -- wp rewrite structure '/%postname%' --hard
+
+# 2. write the standard WP .htaccess (as root, via the cli container)
+npx wp-env run cli -- bash -c 'cat > /var/www/html/.htaccess <<EOF
+# BEGIN WordPress
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\\.php\$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+</IfModule>
+# END WordPress
+EOF'
+```
+
+After this the Settings page can save, REST routes resolve, and the block editor works normally. The file persists for the life of the env -- only re-run after a destroy.
 
 ### Traditional setup
 
@@ -110,6 +135,19 @@ add_filter( 'invintus/player/script/url', function() {
 
 The override is scoped to the screens that actually need the player (the Invintus settings page, the block editor, and front-end posts with the block). It does not load on unrelated wp-admin screens.
 
+### Cross-origin player builds
+
+If the override URL points to a build that uses dynamic `import()` for its own chunks (some bundlers split runtime code this way), the browser will refuse to resolve the relative module specifiers unless the `<script>` tag opts into CORS. Symptom: errors like `Failed to resolve module specifier './chunks/...'. The base URL is about:blank because import() is called from a CORS-cross-origin script.`
+
+Add a companion filter alongside the URL override:
+
+```php
+add_filter( 'invintus/player/script/url',         fn() => 'https://player.beta.invintusmedia.com/app.js' );
+add_filter( 'invintus/player/script/crossorigin', fn() => 'anonymous' );
+```
+
+This emits `crossorigin="anonymous"` on the player `<script>` tag. The target URL must return `Access-Control-Allow-Origin: *` (or matching) for the script to load -- if it doesn't, the script load itself will fail with a CORS error. The default URL does not need CORS, so leave the filter off if you're not overriding the URL.
+
 ## Extension points
 
 Most behavior is filterable. Grep `apply_filters` in `inc/` for the complete list. Highlights:
@@ -117,6 +155,7 @@ Most behavior is filterable. Grep `apply_filters` in `inc/` for the complete lis
 | Filter                              | Default                                | Purpose                              |
 |---                                  |---                                     |---                                   |
 | `invintus/player/script/url`        | `https://player.invintus.com/app.js`   | Player JS source URL                 |
+| `invintus/player/script/crossorigin`| `''` (no attribute)                    | `crossorigin` attribute on player tag (set to `'anonymous'` for cross-origin builds with dynamic imports) |
 | `invintus/api/url`                  | `https://api.v3.invintus.com/v2`       | Invintus API base                    |
 | `invintus/register/slug/cpt`        | `invintus_video`                       | CPT slug                             |
 | `invintus/register/slug/rewrite`    | `video`                                | Front-end rewrite slug               |

--- a/README.md
+++ b/README.md
@@ -1,108 +1,172 @@
 # Invintus WordPress Plugin
 
-A WordPress plugin for integrating Invintus video content into your WordPress site. This plugin provides a custom post type for managing Invintus videos and a settings page for configuring your Invintus API credentials.
+WordPress plugin that integrates the Invintus video platform. Registers an `invintus_video` custom post type, a Gutenberg block for embedding events, an admin settings page for API credentials and player preferences, and webhook routes that keep videos in sync with the Invintus API.
 
 ## Features
 
-- Custom post type for Invintus videos
-- Settings page for API configuration
-- Player preference selection
-- Modern block editor support
-- Automatic video embedding
+- `invintus_video` CPT with `invintus_category` / `invintus_tag` taxonomies
+- Gutenberg block (`taproot/invintus`) with live editor preview
+- Settings UI for API key, client ID, default player preference, and watch redirect path
+- REST endpoints under `invintus/v2/` for webhook upserts and player preferences
+- `invintus/...` filters for extending almost everything (see `Extension points` below)
 
 ## Installation
 
-### Automatic Installation (Recommended)
+Most installs pull from the release dist (see `Repository layout`).
 
-1. Log in to your WordPress dashboard
-2. Go to Plugins > Add New
-3. Click the "Upload Plugin" button at the top of the page
-4. Click "Choose File" and select the invintus.zip file
-5. Click "Install Now"
-6. After installation completes, click "Activate Plugin"
+1. Download the latest ZIP from the [dist repo releases page](https://github.com/TVWIT/invintus-wp-plugin-dist/releases).
+2. WP Admin > Plugins > Add New > Upload Plugin > choose the ZIP > Install + Activate.
+3. Configure under `Invintus Videos > Settings`, or define the constants in `wp-config.php`:
+   ```php
+   define( 'INVINTUS_API_KEY',   'your-api-key'   );
+   define( 'INVINTUS_CLIENT_ID', 'your-client-id' );
+   ```
 
-### Manual Installation
-
-1. Download the latest release zip file
-2. Unzip the file
-3. Upload the `invintus` folder to your `/wp-content/plugins/` directory via FTP or file manager
-4. Log in to your WordPress dashboard
-5. Go to Plugins > Installed Plugins
-6. Find "Invintus" in the list and click "Activate"
+Constants take precedence over the UI when defined.
 
 ## Requirements
 
 - WordPress 5.8+
 - PHP 7.4+
-- Node.js 16+ (for development)
-- Composer (for PHP dependencies)
+- Node.js 16+ and Composer (development only)
 
-## Development Setup
+## Development
 
-1. Clone this repository into your WordPress plugins directory:
-   ```bash
-   cd wp-content/plugins
-   git clone [repository-url] invintus
-   ```
+Two ways to run the plugin locally. Pick one.
 
-2. Install PHP dependencies:
-   ```bash
-   composer install
-   ```
+### Quickstart with wp-env (recommended)
 
-3. Install Node.js dependencies:
-   ```bash
-   npm install
-   ```
-
-4. Build the assets:
-   ```bash
-   # For development (with watch mode)
-   npm run dev
-
-   # For production
-   npm run build
-   ```
-
-## Configuration
-
-1. Activate the plugin in WordPress admin
-2. Go to Invintus Videos > Settings
-3. Enter your API credentials:
-   - API Key
-   - Client ID
-
-Alternatively, you can define these in your `wp-config.php`:
-```php
-define( 'INVINTUS_API_KEY', 'your-api-key' );
-define( 'INVINTUS_CLIENT_ID', 'your-client-id' );
-```
-
-## Creating a Release
-
-This plugin includes a release script that creates a distribution-ready ZIP file. The script:
-1. Runs `composer install` with production optimizations
-2. Excludes development files
-3. Creates a ZIP file with only the necessary files
-
-To create a release:
+Spins up a Dockerized WP at `http://localhost:8888`, mounts this repo as a plugin, and gives you `wp` / `composer` / `phpcs` inside the container. No host PHP needed.
 
 ```bash
-# Basic usage (outputs to current directory)
-node create-release.js
-
-# Specify output directory
-node create-release.js outdir=/path/to/output
+npm install
+npm run env:start
 ```
 
-The script will:
-1. Run `composer install --no-dev --optimize-autoloader`
-2. Create a ZIP file containing only production files
-3. Exclude development files like:
-   - `.git`
-   - `node_modules`
-   - Development configuration files
-   - Build files
-   - Test files
+Then visit http://localhost:8888/wp-admin (login: `admin` / `password`).
 
-The resulting ZIP file can be used to install the plugin on any WordPress site.
+To run the plugin the way it actually ships to users (compiled `build/`, vendored `vendor/`, no dev tooling), build a dist candidate and tell wp-env to mount that instead:
+
+```bash
+npm run dist:build   # writes .dist-candidate/invintus/
+```
+
+Then create `.wp-env.override.json` (gitignored) at the repo root:
+
+```json
+{
+  "plugins": ["./.dist-candidate/invintus"],
+  "config": {
+    "INVINTUS_API_KEY":   "your-key",
+    "INVINTUS_CLIENT_ID": "your-client-id"
+  }
+}
+```
+
+`npm run env:start` again to pick up the override.
+
+Other env scripts: `env:stop`, `env:destroy`, `env:clean`, `env:logs`, `env:wp` (wp-cli passthrough), `env:composer`, `env:phpcs`.
+
+> Note: wp-env 9.x does not auto-write `.htaccess`, so pretty REST URLs (`/wp-json/...`) return Apache 404s on a fresh install. Either use the query-string form (`/index.php?rest_route=/...`) or write a standard WP `.htaccess` once into the container. Logging into wp-admin and saving the Permalinks page is the simplest fix.
+
+### Traditional setup
+
+Clone into an existing WP install:
+
+```bash
+cd wp-content/plugins
+git clone https://github.com/TVWIT/invintus-wp-plugin invintus
+cd invintus
+composer install
+npm install
+npm run start   # watch-mode dev build
+```
+
+## Build, lint, format
+
+| Script                 | What it does                                       |
+|---                     |---                                                 |
+| `npm run start`        | Watch-mode webpack build (also copies `render.php`)|
+| `npm run build`        | Production build into `build/`                     |
+| `npm run lint:js`      | ESLint on JS sources                               |
+| `npm run lint:css`     | Stylelint on SCSS sources                          |
+| `npm run format`       | Prettier across the tree                           |
+| `composer php:lint`    | PHPCS (WordPress Coding Standards + PHPCompat)     |
+| `composer php:lint:autofix`   | PHPCBF                                      |
+| `composer php:lint:changed`   | PHPCS on unstaged changes only              |
+
+## Overriding the player URL
+
+The player script source is filterable. Drop a [must-use plugin](https://wordpress.org/documentation/article/must-use-plugins/) at `wp-content/mu-plugins/invintus-player.php` to redirect it:
+
+```php
+<?php
+add_filter( 'invintus/player/script/url', function() {
+    return 'https://player.beta.invintusmedia.com/app.js';
+} );
+```
+
+`mu-plugins` load before regular plugins, can't be deactivated through the admin UI, and survive plugin updates -- ideal for "site policy" overrides that shouldn't ride with a release. Remove the file to revert.
+
+The override is scoped to the screens that actually need the player (the Invintus settings page, the block editor, and front-end posts with the block). It does not load on unrelated wp-admin screens.
+
+## Extension points
+
+Most behavior is filterable. Grep `apply_filters` in `inc/` for the complete list. Highlights:
+
+| Filter                              | Default                                | Purpose                              |
+|---                                  |---                                     |---                                   |
+| `invintus/player/script/url`        | `https://player.invintus.com/app.js`   | Player JS source URL                 |
+| `invintus/api/url`                  | `https://api.v3.invintus.com/v2`       | Invintus API base                    |
+| `invintus/register/slug/cpt`        | `invintus_video`                       | CPT slug                             |
+| `invintus/register/slug/rewrite`    | `video`                                | Front-end rewrite slug               |
+| `invintus/events/watch/endpoint`    | `video/watch`                          | `/watch` redirect base               |
+| `invintus/block/attributes`         | (built-ins)                            | Add custom block attributes          |
+
+## Repository layout
+
+The plugin lives in two repositories. Knowing which is which matters before you make changes.
+
+| Repo | Purpose | What's in it |
+|---   |---      |---           |
+| [`TVWIT/invintus-wp-plugin`](https://github.com/TVWIT/invintus-wp-plugin) (this repo) | Source of truth. All development happens here. | Full source: `src/`, `inc/`, build config, CI, tests, dev tooling. |
+| [`TVWIT/invintus-wp-plugin-dist`](https://github.com/TVWIT/invintus-wp-plugin-dist) | Distribution. Where releases are published. | Build artifacts only: compiled `build/`, vendored `vendor/`, runtime PHP. No `src/`, no `package.json`, no CI. |
+
+The dist repo is written **automatically** by this repo's release workflow. Do not hand-edit it -- changes get overwritten on the next tagged release. Install or update from GitHub Releases on the dist repo, or pull via Composer / `wp plugin install <url>`.
+
+> An older repo named `TVWIT/wp-plugin-invintus` (default branch `master`) is a deprecated predecessor and should be ignored. It has not received updates since early 2025.
+
+## Releasing a new version
+
+Releases are driven by **git tags** on this repo. The CI workflow ([`.github/workflows/main.yml`](.github/workflows/main.yml)) handles the build and publishes to the dist repo automatically.
+
+1. Land your changes on `main` via PR.
+2. Bump the version in all three places (these must match):
+   - `invintus.php` plugin header (`Version:` line)
+   - `invintus.php` `INVINTUS_PLUGIN_VERSION` constant
+   - `package.json` `"version"` field
+3. Commit the version bump on `main`.
+4. Tag and push:
+   ```bash
+   git tag v2.0.11
+   git push origin v2.0.11
+   ```
+5. The `Build and Deploy to Dist Repo` workflow fires on the `v*.*.*` tag and:
+   - Runs `npm ci` and `composer install --no-dev --optimize-autoloader`
+   - Clones the dist repo, wipes it, and copies in `build assets inc vendor templates views invintus.php LICENSE doc.md` plus a stripped `composer.json`
+   - Commits, tags `v2.0.11` on the dist repo, and creates a GitHub Release there with `invintus-wp-plugin.zip` attached
+
+### Local fallback: `create-release.js`
+
+To build a release ZIP without going through CI (e.g. to hand a one-off build to a partner for testing):
+
+```bash
+node create-release.js                   # output to current directory
+node create-release.js outdir=/some/path # specify output directory
+```
+
+It runs `composer install --no-dev --optimize-autoloader` and zips per `.distignore`. The resulting ZIP is installable but **does not** update the dist repo -- only the tag-based CI flow does that.
+
+## License
+
+ISC -- see [`LICENSE`](LICENSE).

--- a/doc.md
+++ b/doc.md
@@ -129,9 +129,44 @@ Why `mu-plugins`:
 
 To remove the override, delete the file. No restart or plugin reactivation required.
 
-The override can be scoped to specific routes by checking the current request inside the filter callback (e.g. `is_page()`, `is_singular()`, or `$_SERVER['REQUEST_URI']`). Always accept the default URL as the first argument and return it as the fallback so other filters and the default remain in effect.
-
 The player script is only enqueued where it is actually needed: the Invintus Settings page, the block editor, and front-end posts that contain the Invintus block. The filter does not run on screens that do not load the player.
+
+### Scoped overrides
+
+The override can be limited to specific routes by checking the current request inside the filter callback. Always accept the default URL as the first argument and return it as the fallback so other filters and the default remain in effect.
+
+**One specific page (by slug):**
+
+```php
+add_filter( 'invintus/player/script/url', function( $url ) {
+    if ( is_page( 'beta-player-test' ) ) {
+        return 'https://example.com/path/to/your/app.js';
+    }
+    return $url;
+} );
+```
+
+**One specific post (by ID):**
+
+```php
+add_filter( 'invintus/player/script/url', function( $url ) {
+    if ( is_singular() && get_the_ID() === 1234 ) {
+        return 'https://example.com/path/to/your/app.js';
+    }
+    return $url;
+} );
+```
+
+**One URL path prefix (works for any route, including custom rewrites):**
+
+```php
+add_filter( 'invintus/player/script/url', function( $url ) {
+    if ( str_starts_with( $_SERVER['REQUEST_URI'] ?? '', '/preview-beta' ) ) {
+        return 'https://example.com/path/to/your/app.js';
+    }
+    return $url;
+} );
+```
 
 ### Cross-origin player builds
 
@@ -140,7 +175,7 @@ Some player builds split their runtime into separate chunks loaded via dynamic `
 If the override URL points to such a build, add a companion filter alongside the URL override:
 
 ```php
-add_filter( 'invintus/player/script/url',         function() {
+add_filter( 'invintus/player/script/url', function() {
     return 'https://example.com/path/to/your/app.js';
 } );
 

--- a/doc.md
+++ b/doc.md
@@ -108,6 +108,31 @@ You can configure various settings for the plugin:
 1. Go to Invintus Videos > Settings.
 2. Update the settings as needed, including API credentials and player preferences.
 
+## Advanced: overriding the player URL
+
+By default the plugin loads the Invintus player from `https://player.invintus.com/app.js`. Sites that need to point at a different build (for example, partner-supplied or self-hosted) can override the URL via a WordPress filter without modifying the plugin.
+
+The recommended pattern is a [must-use plugin](https://wordpress.org/documentation/article/must-use-plugins/) at `wp-content/mu-plugins/invintus-player.php`:
+
+```php
+<?php
+add_filter( 'invintus/player/script/url', function( $url ) {
+    return 'https://example.com/path/to/your/app.js';
+} );
+```
+
+Why `mu-plugins`:
+
+- Loads before regular plugins, so the filter is in place when the plugin asks for the URL.
+- Cannot be deactivated from the wp-admin Plugins screen.
+- Survives plugin updates -- updating the Invintus plugin will not touch your override.
+
+To remove the override, delete the file. No restart or plugin reactivation required.
+
+The override can be scoped to specific routes by checking the current request inside the filter callback (e.g. `is_page()`, `is_singular()`, or `$_SERVER['REQUEST_URI']`). Always accept the default URL as the first argument and return it as the fallback so other filters and the default remain in effect.
+
+The player script is only enqueued where it is actually needed: the Invintus Settings page, the block editor, and front-end posts that contain the Invintus block. The filter does not run on screens that do not load the player.
+
 ## Support
 
 For support, please contact support@invintus.com.

--- a/doc.md
+++ b/doc.md
@@ -133,6 +133,24 @@ The override can be scoped to specific routes by checking the current request in
 
 The player script is only enqueued where it is actually needed: the Invintus Settings page, the block editor, and front-end posts that contain the Invintus block. The filter does not run on screens that do not load the player.
 
+### Cross-origin player builds
+
+Some player builds split their runtime into separate chunks loaded via dynamic `import()`. When the player is served from a different origin than the site, the browser will refuse to resolve the relative chunk URLs unless the `<script>` tag is marked as a CORS-enabled request. Symptom: console errors like `Failed to resolve module specifier './chunks/...'`.
+
+If the override URL points to such a build, add a companion filter alongside the URL override:
+
+```php
+add_filter( 'invintus/player/script/url',         function() {
+    return 'https://example.com/path/to/your/app.js';
+} );
+
+add_filter( 'invintus/player/script/crossorigin', function() {
+    return 'anonymous';
+} );
+```
+
+The `invintus/player/script/crossorigin` filter sets the `crossorigin` attribute on the player `<script>` tag. The target URL must respond with `Access-Control-Allow-Origin: *` (or a matching origin) -- if it does not, the browser will reject the script load. The default Invintus player URL does not require this, so the filter should only be added when overriding the URL.
+
 ## Support
 
 For support, please contact support@invintus.com.

--- a/inc/Block.php
+++ b/inc/Block.php
@@ -72,11 +72,6 @@ class Block
     if ( !self::$script_localized && ( has_block( 'taproot/invintus' ) || has_block( 'acf/invintus-event' ) ) ):
       wp_enqueue_script( 'invintus-player-script', $this->invintus()->get_invintus_script_url(), [], null, true );
 
-      $crossorigin = apply_filters( 'invintus/player/script/crossorigin', '' );
-      if ( $crossorigin ):
-        wp_script_add_data( 'invintus-player-script', 'crossorigin', $crossorigin );
-      endif;
-
       wp_localize_script( 'invintus-player-script', 'invintusConfig', [
         'clientId'     => $this->client_id,
         'playerPrefID' => $settings->get_option( 'invintus_player_preference_default' ) ?? '',

--- a/inc/Block.php
+++ b/inc/Block.php
@@ -72,6 +72,11 @@ class Block
     if ( !self::$script_localized && ( has_block( 'taproot/invintus' ) || has_block( 'acf/invintus-event' ) ) ):
       wp_enqueue_script( 'invintus-player-script', $this->invintus()->get_invintus_script_url(), [], null, true );
 
+      $crossorigin = apply_filters( 'invintus/player/script/crossorigin', '' );
+      if ( $crossorigin ):
+        wp_script_add_data( 'invintus-player-script', 'crossorigin', $crossorigin );
+      endif;
+
       wp_localize_script( 'invintus-player-script', 'invintusConfig', [
         'clientId'     => $this->client_id,
         'playerPrefID' => $settings->get_option( 'invintus_player_preference_default' ) ?? '',

--- a/inc/Invintus.php
+++ b/inc/Invintus.php
@@ -632,5 +632,34 @@ class Invintus
     add_filter( 'get_post_status', [$this, 'maybe_allow_future_events'], 10, 2 );
     add_filter( 'get_post_status', [$this, 'allow_live_events'], 10, 2 );
     add_filter( 'init', [$this, 'preload_content'] );
+    add_filter( 'script_loader_tag', [$this, 'maybe_add_player_crossorigin'], 10, 2 );
+  }
+
+  /**
+   * Injects a crossorigin attribute on the player <script> tag when the
+   * invintus/player/script/crossorigin filter returns a non-empty value.
+   *
+   * Required when overriding the player URL to a cross-origin build whose
+   * runtime loads chunks via dynamic import(): without CORS opt-in, the
+   * browser strips the script's base URL and rejects the relative chunk
+   * specifiers. The target URL must serve Access-Control-Allow-Origin
+   * headers matching the site origin.
+   *
+   * Applies to both enqueue handles used by the plugin: 'invintus-app'
+   * (Settings page + block editor) and 'invintus-player-script' (front-end
+   * block render).
+   *
+   * @param  string $tag    The full <script> tag HTML.
+   * @param  string $handle The script handle being rendered.
+   * @return string         The (possibly modified) tag.
+   */
+  public function maybe_add_player_crossorigin( $tag, $handle )
+  {
+    if ( !in_array( $handle, ['invintus-app', 'invintus-player-script'], true ) ) return $tag;
+
+    $crossorigin = apply_filters( 'invintus/player/script/crossorigin', '' );
+    if ( !$crossorigin ) return $tag;
+
+    return str_replace( '<script ', sprintf( '<script crossorigin="%s" ', esc_attr( $crossorigin ) ), $tag );
   }
 }

--- a/inc/Settings.php
+++ b/inc/Settings.php
@@ -116,6 +116,11 @@ class Settings
 
     wp_register_script( 'invintus-app', $this->invintus()->get_invintus_script_url(), ['underscore'], null, true );
 
+    $crossorigin = apply_filters( 'invintus/player/script/crossorigin', '' );
+    if ( $crossorigin ):
+      wp_script_add_data( 'invintus-app', 'crossorigin', $crossorigin );
+    endif;
+
     wp_localize_script( 'invintus-app', 'invintusConfig', [
       'nonce'                => wp_create_nonce( 'wp_rest' ),
       'clientId'             => $this->get_client_id(),

--- a/inc/Settings.php
+++ b/inc/Settings.php
@@ -116,11 +116,6 @@ class Settings
 
     wp_register_script( 'invintus-app', $this->invintus()->get_invintus_script_url(), ['underscore'], null, true );
 
-    $crossorigin = apply_filters( 'invintus/player/script/crossorigin', '' );
-    if ( $crossorigin ):
-      wp_script_add_data( 'invintus-app', 'crossorigin', $crossorigin );
-    endif;
-
     wp_localize_script( 'invintus-app', 'invintusConfig', [
       'nonce'                => wp_create_nonce( 'wp_rest' ),
       'clientId'             => $this->get_client_id(),

--- a/inc/Settings.php
+++ b/inc/Settings.php
@@ -102,13 +102,20 @@ class Settings
    */
   public function admin_scripts( $hook_suffix )
   {
-    // Get the current screen
     $screen = get_current_screen();
 
-    // Register and enqueue the Invintus player script
+    // Only load the player on screens that actually use it: the Invintus
+    // settings page, and any block editor screen (where the Invintus block
+    // can be inserted and rendered as a live preview via edit.js). Loading
+    // it elsewhere injects player CSS into every wp-admin screen and can
+    // break unrelated admin UI.
+    $is_settings_page = $hook_suffix === $this->hook_suffix;
+    $is_block_editor  = $screen && method_exists( $screen, 'is_block_editor' ) && $screen->is_block_editor();
+
+    if ( !$is_settings_page && !$is_block_editor ) return;
+
     wp_register_script( 'invintus-app', $this->invintus()->get_invintus_script_url(), ['underscore'], null, true );
 
-    // Localize the script with necessary data
     wp_localize_script( 'invintus-app', 'invintusConfig', [
       'nonce'                => wp_create_nonce( 'wp_rest' ),
       'clientId'             => $this->get_client_id(),
@@ -120,11 +127,9 @@ class Settings
       'defaultWatchEndpoint' => $this->invintus()->get_default_watch_endpoint(),
     ] );
 
-    // Always enqueue the script on admin pages
     wp_enqueue_script( 'invintus-app' );
 
-    // If we're on the options page, enqueue additional scripts and styles
-    if ( $hook_suffix === $this->hook_suffix ):
+    if ( $is_settings_page ):
       $this->enqueue_options_page_styles();
       $this->enqueue_options_page_scripts();
     endif;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
+        "@wordpress/env": "^9.10.0",
         "@wordpress/scripts": "^26.16.0",
         "eslint": "^8.57.1",
         "eslint-config-prettier": "^10.0.1",
@@ -2495,6 +2496,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -3157,11 +3175,41 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "dev": true
     },
+    "node_modules/@simple-git/args-pathspec": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@simple-git/argv-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@simple-git/args-pathspec": "^1.0.3"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -3438,6 +3486,19 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@tannin/compile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
@@ -3553,6 +3614,19 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -3653,6 +3727,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
@@ -3715,6 +3796,16 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -3774,6 +3865,16 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
@@ -4471,6 +4572,80 @@
       },
       "peerDependencies": {
         "@playwright/test": ">=1"
+      }
+    },
+    "node_modules/@wordpress/env": {
+      "version": "9.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-9.10.0.tgz",
+      "integrity": "sha512-GqUg1XdrUXI3l5NhHhEZisrccW+VPqJSU5xO1IXybI6KOvmSecidxWEqlMj26vzu2P5aLCWZcx28QkrrY3jvdg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "copy-dir": "^1.3.0",
+        "docker-compose": "^0.24.3",
+        "extract-zip": "^1.6.7",
+        "got": "^11.8.5",
+        "inquirer": "^7.1.0",
+        "js-yaml": "^3.13.1",
+        "ora": "^4.0.2",
+        "rimraf": "^3.0.2",
+        "simple-git": "^3.5.0",
+        "terminal-link": "^2.0.0",
+        "yargs": "^17.3.0"
+      },
+      "bin": {
+        "wp-env": "bin/wp-env"
+      }
+    },
+    "node_modules/@wordpress/env/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@wordpress/env/node_modules/extract-zip": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      }
+    },
+    "node_modules/@wordpress/env/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/env/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@wordpress/eslint-plugin": {
@@ -5876,6 +6051,51 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -6068,6 +6288,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/check-node-version": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-4.2.1.tgz",
@@ -6186,6 +6413,42 @@
         "webpack": "*"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -6198,6 +6461,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/clone-deep": {
@@ -6214,6 +6487,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/co": {
@@ -6349,6 +6635,62 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/configstore": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
@@ -6439,6 +6781,13 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
+    },
+    "node_modules/copy-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/copy-dir/-/copy-dir-1.3.0.tgz",
+      "integrity": "sha512-Q4+qBFnN4bwGwvtXXzbp4P/4iNk0MaiGAzvQ8OiMtlLjkIKjmNN689uVzShSM0908q7GoFHXIPx4zi75ocoaHw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/copy-webpack-plugin": {
       "version": "10.2.4",
@@ -7075,6 +7424,35 @@
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
       "dev": true
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
@@ -7123,6 +7501,29 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/define-data-property": {
@@ -7330,6 +7731,35 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/docker-compose": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-0.24.8.tgz",
+      "integrity": "sha512-plizRs/Vf15H+GCVxq2EUvyPK7ei9b/cVesHvjnX4xaXjM9spHe2Ytq0BitndFgvTJ3E3NljPNUEl7BAN43iZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/docker-compose/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/doctrine": {
@@ -8899,6 +9329,34 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -9054,6 +9512,32 @@
       "dev": true,
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -9754,6 +10238,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -10028,6 +10538,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
@@ -10115,6 +10632,33 @@
         "@types/express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/http2-wrapper/node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -10331,6 +10875,51 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
+    },
+    "node_modules/inquirer": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.19",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.6.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -10662,6 +11251,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-map": {
@@ -12419,6 +13018,16 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lru_map": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
@@ -12826,6 +13435,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -12945,6 +13564,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -12978,6 +13610,13 @@
       "bin": {
         "multicast-dns": "cli.js"
       }
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/nanoid": {
       "version": "3.3.8",
@@ -13150,6 +13789,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm-bundled": {
@@ -13491,11 +14143,149 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ora": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-4.1.1.tgz",
+      "integrity": "sha512-sjYP8QyVWBpBZWD6Vr1M/KwknSw6kJOz41tvGMlwWeClHBtYKTbHMki1PsLZnxKpXMPbTKv9b3pjQu3REib96A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.2.0",
+        "is-interactive": "^1.0.0",
+        "log-symbols": "^3.0.0",
+        "mute-stream": "0.0.8",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/ora/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ora/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/ora/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^2.4.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ora/node_modules/log-symbols/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13515,6 +14305,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -15405,6 +16205,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve-bin": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/resolve-bin/-/resolve-bin-0.4.3.tgz",
@@ -15457,6 +16264,33 @@
         "node": ">=10"
       }
     },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -15496,6 +16330,16 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/run-con": {
@@ -16163,6 +17007,24 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/simple-git": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
     },
     "node_modules/sirv": {
       "version": "2.0.4",
@@ -17106,6 +17968,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/terminal-link": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/terser": {
       "version": "5.39.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
@@ -17280,6 +18159,19 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -17574,6 +18466,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
@@ -17965,6 +18864,16 @@
       "dev": true,
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/web-vitals": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,17 @@
     "lint:js": "wp-scripts lint-js",
     "packages-update": "wp-scripts packages-update",
     "plugin-zip": "wp-scripts plugin-zip",
-    "start": "wp-scripts start --webpack-copy-php"
+    "start": "wp-scripts start --webpack-copy-php",
+    "env": "wp-env",
+    "env:start": "wp-env start",
+    "env:stop": "wp-env stop",
+    "env:destroy": "wp-env destroy",
+    "env:clean": "wp-env clean all",
+    "env:logs": "wp-env logs",
+    "env:wp": "wp-env run cli wp",
+    "env:composer": "wp-env run cli --env-cwd=wp-content/plugins/invintus-wp-plugin composer",
+    "env:phpcs": "wp-env run cli --env-cwd=wp-content/plugins/invintus-wp-plugin composer php:lint",
+    "dist:build": "bash scripts/build-dist.sh"
   },
   "keywords": [
     "invintus",
@@ -21,6 +31,7 @@
   "author": "Lucas Williams <lucas@taproot.agency> (https://taproot.agency)",
   "license": "ISC",
   "devDependencies": {
+    "@wordpress/env": "^9.10.0",
     "@wordpress/scripts": "^26.16.0",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "env:wp": "wp-env run cli wp",
     "env:composer": "wp-env run cli --env-cwd=wp-content/plugins/invintus-wp-plugin composer",
     "env:phpcs": "wp-env run cli --env-cwd=wp-content/plugins/invintus-wp-plugin composer php:lint",
+    "env:reset": "bash scripts/reset-env.sh",
     "dist:build": "bash scripts/build-dist.sh"
   },
   "keywords": [

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Builds a DIST candidate that matches what CI publishes to
+# TVWIT/invintus-wp-plugin-dist. Use this to test the plugin the way a
+# real client would receive it -- compiled assets + prod composer deps,
+# none of the dev tooling.
+#
+# Output: .dist-candidate/invintus/   (mountable as a wp-env plugin)
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+INCLUDE=(build assets inc vendor templates views invintus.php LICENSE doc.md)
+
+echo "==> npm run build (compiles src/ into build/)"
+npm run build
+
+echo "==> composer install --no-dev (via dockerized composer; no host PHP needed)"
+docker run --rm \
+  -v "$ROOT:/app" \
+  -w /app \
+  composer:2 install --no-dev --optimize-autoloader --no-interaction
+
+echo "==> Assembling .dist-candidate/invintus/"
+rm -rf .dist-candidate
+mkdir -p .dist-candidate/invintus
+for f in "${INCLUDE[@]}"; do
+  if [[ -e "$f" ]]; then
+    cp -R "$f" ".dist-candidate/invintus/"
+  else
+    echo "    WARNING: $f not found, skipping"
+  fi
+done
+
+echo
+echo "Dist candidate ready at: .dist-candidate/invintus"
+echo "Point wp-env at it via .wp-env.override.json (already set up)."

--- a/scripts/reset-env.sh
+++ b/scripts/reset-env.sh
@@ -36,6 +36,15 @@ npm run dist:build
 echo "==> starting wp-env"
 npm run env:start
 
+# Docker Desktop on macOS can lose bind-mount visibility when the host
+# path is removed and recreated (which is exactly what we just did to
+# .dist-candidate). The container ends up seeing an empty plugin dir
+# even though the host path is populated. Cycle stop+start to force
+# Docker to re-resolve the mount.
+echo "==> stop+start cycle to re-resolve bind-mount"
+npx wp-env stop
+npx wp-env start
+
 echo "==> post-start bootstrap: permalink structure"
 npx wp-env run cli -- wp rewrite structure '/%postname%' --hard
 

--- a/scripts/reset-env.sh
+++ b/scripts/reset-env.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Scorched-earth reset of the local wp-env environment.
+#
+# Tears down wp-env (containers + volumes + db), removes build
+# artifacts, rebuilds the dist candidate, starts wp-env from scratch,
+# and applies the one-time post-start bootstrap (permalink structure +
+# .htaccess) so REST routes resolve and the Settings page can save.
+#
+# Use this when you want to verify the "fresh clone" recipe end-to-end
+# or when you suspect env state is the cause of a bug.
+#
+# WARNING: destroys the local wp-env database. Anything created in
+# wp-admin (posts, settings, users) will be gone.
+#
+# Does NOT touch node_modules. If you also want a fresh npm install,
+# delete node_modules manually before running this.
+#
+# Usage:
+#   bash scripts/reset-env.sh
+#   npm run env:reset
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+echo "==> destroying wp-env (containers + volumes + db)"
+echo y | npm run env:destroy
+
+echo "==> removing build artifacts (build/, vendor/, .dist-candidate/)"
+rm -rf build/ vendor/ .dist-candidate/
+
+echo "==> rebuilding dist candidate"
+npm run dist:build
+
+echo "==> starting wp-env"
+npm run env:start
+
+echo "==> post-start bootstrap: permalink structure"
+npx wp-env run cli -- wp rewrite structure '/%postname%' --hard
+
+echo "==> post-start bootstrap: .htaccess"
+npx wp-env run cli -- bash -c 'cat > /var/www/html/.htaccess <<EOF
+# BEGIN WordPress
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+RewriteBase /
+RewriteRule ^index\\.php\$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+</IfModule>
+# END WordPress
+EOF'
+
+echo
+echo "==> ready"
+echo "    http://localhost:8888/wp-admin   (admin / password)"
+echo "    plugin mount: $(grep -oE '"plugins": \[[^]]+\]' .wp-env.override.json 2>/dev/null || grep -oE '"plugins": \[[^]]+\]' .wp-env.json)"
+echo "    mu-plugins:   $(ls .local-mu-plugins/ 2>/dev/null | grep -v '\.off$' | tr '\n' ' ' || echo '(none)')"


### PR DESCRIPTION
# Version `2.0.12`

- Player script now only enqueued on screens that need it (Settings + block editor + posts with the block)
- New `invintus/player/script/crossorigin` filter. Pair it with your existing `invintus/player/script/url` filter, returning `'anonymous'`, to support cross-origin player builds that use dynamic `import()`.
- Documentation: override patterns and scoped-route examples