### PR TITLE
fix(view): guard player launch until Invintus global is ready

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -23,7 +23,19 @@
 const invintusWP = ( () => {
   return {
     init() {
-      this.loadPlayers()
+      this.whenReady( () => this.loadPlayers() )
+    },
+    // The player SDK (window.Invintus) is enqueued as a separate script with no
+    // guaranteed execution order relative to this view script (WP defers block
+    // view scripts by default). Poll briefly for the global before launching so
+    // we never hit "Invintus is not defined" when this script wins the race.
+    whenReady( cb, attempts = 0 ) {
+      if ( typeof window.Invintus !== 'undefined' && typeof window.Invintus.launch === 'function' ) return cb()
+      if ( attempts >= 200 ) { // ~10s at 50ms
+        console.error( '[invintus] player SDK never loaded -- check the invintus-player-script <script> tag and its URL' )
+        return
+      }
+      setTimeout( () => this.whenReady( cb, attempts + 1 ), 50 )
     },
     loadPlayers() {
       const $players = document.querySelectorAll( '.invintus-player' )


### PR DESCRIPTION
## Problem

`src/view.js` calls `Invintus.launch()` at top-level on execution, but the player SDK (`window.Invintus`, defined by `app.js`) is enqueued as a separate script (`invintus-player-script`) with no declared dependency on the view script. WordPress defers block view scripts by default, so when the SDK script loads late, is async/deferred by a site's perf layer, or fails to load entirely, the view script wins the race and throws:

```
Uncaught ReferenceError: Invintus is not defined
    loadPlayers .../invintus-wp-plugin-3/build/view.js
```

Originally surfaced on a partner site where a client shim filtered `invintus/player/script/url` down to the bare host (`https://player.beta.invintusmedia.com`, missing `/app.js`). The bare host serves the player SPA's index HTML, the browser refuses to execute HTML as a script (`NS_ERROR_...`, 0 B), `app.js` never runs, and the view script throws.

## Change

Poll for `window.Invintus` (50ms x 200, ~10s) before launching:

- SDK already present -> launch is synchronous, same as before.
- SDK arrives late -> guard launches once it appears.
- SDK never loads -> emit `[invintus] player SDK never loaded -- check the invintus-player-script <script> tag and its URL` instead of a cryptic `ReferenceError`.

## Scope

Defensive diagnostic improvement only. It does **not** make a misconfigured player script URL work -- that must be fixed where the `invintus/player/script/url` filter is set (client-side, in that incident's case).

## Verification

- Headless Chromium against a wp-env page reproducing the exact failing condition (beta `app.js`, `async` + `crossorigin`, deferred view script): no `ReferenceError`, SDK defined, player mounted.
- Virtual-clock unit harness over the real built `view.js` across three timing cases (SDK late / never / already present) all pass; old unguarded code reproduces the `ReferenceError` under the same race.
- Hands-on docker wp instance

🤖 Generated with [Claude Code](https://claude.com/claude-code) and a human being